### PR TITLE
Add pkgver to stop makepkg error

### DIFF
--- a/PKGBUILD-git
+++ b/PKGBUILD-git
@@ -1,7 +1,7 @@
 # Maintainer: mychris <just dot mychris funnychar googlemail dot com>
 pkgname=simple-stopwatch-git
 _gitname=simple-stopwatch
-pkgver=
+pkgver=1.2.0
 pkgrel=1
 pkgdesc="A very simple python3, ncurses based terminal stopwatch."
 arch=('any')


### PR DESCRIPTION
On Arch Linux, attempting to build the package using this `PKGBUILD` (using the instructions given in the `README`) causes an error from `makepkg`: `==> ERROR: pkgver is not allowed to be empty.` Therefore, I have added a version number from `setup.py` so that `makepkg` works correctly.